### PR TITLE
Fix for invalid register access in promise_result functions

### DIFF
--- a/ports/webassembly-near/modnear.c
+++ b/ports/webassembly-near/modnear.c
@@ -682,16 +682,18 @@ MP_DEFINE_CONST_FUN_OBJ_0(near_promise_results_count_obj, near_promise_results_c
 
 static mp_obj_t near_promise_result(mp_obj_t result_idx)
 {
-  uint64_t result = promise_result(mp_obj_get_int(result_idx), default_temp_register_id);
-  mp_obj_t items[] = { u64_to_mp_int(result), read_default_temp_register_as_bytes() };
+  uint64_t status = promise_result(mp_obj_get_int(result_idx), default_temp_register_id);
+  mp_obj_t result_data = (status == 1) ? read_default_temp_register_as_bytes() : mp_const_none;
+  mp_obj_t items[] = { u64_to_mp_int(status), result_data };
   return mp_obj_new_tuple(2, items);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(near_promise_result_obj, near_promise_result);
 
 static mp_obj_t near_promise_result_as_str(mp_obj_t result_idx)
 {
-  uint64_t result = promise_result(mp_obj_get_int(result_idx), default_temp_register_id);
-  mp_obj_t items[] = { u64_to_mp_int(result), read_default_temp_register_as_str() };
+  uint64_t status = promise_result(mp_obj_get_int(result_idx), default_temp_register_id);
+  mp_obj_t result_data = (status == 1) ? read_default_temp_register_as_str() : mp_const_none;
+  mp_obj_t items[] = { u64_to_mp_int(status), result_data };
   return mp_obj_new_tuple(2, items);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(near_promise_result_as_str_obj, near_promise_result_as_str);


### PR DESCRIPTION
## Problem
Currently, the `near_promise_result` and `near_promise_result_as_str` functions unconditionally read from the default_temp_register_id register, regardless of the status returned by the promise_result host function. This leads to a runtime error when the promise execution fails, resulting in:

```json
"status": {
  "Failure": {
    "ActionError": {
      "index": 0,
      "kind": {
        "FunctionCallError": {
          "ExecutionError": "Accessed invalid register id: 0"
        }
      }
    }
  }
}
```

## Solution
Update both functions to only read from the register when the promise execution was successful (status == 1). Otherwise, return None as the result value.

## Testing
Tested with failing promise execution scenarios, which previously crashed but now correctly return a tuple with the failure status and None for the result data.